### PR TITLE
Make color darker for extension badges with light background

### DIFF
--- a/themes/Morass.json
+++ b/themes/Morass.json
@@ -536,7 +536,7 @@
         "terminal.ansiBrightWhite":"#aeaca9",
         "terminal.ansiBrightYellow":"#fed75d",
         "extensionButton.prominentBackground":"#fdec5a",
-        "extensionButton.prominentForeground":"#ffffff",
+        "extensionButton.prominentForeground":"#1a1f1d",
         "extensionButton.prominentHoverBackground":"#fef28c"
             }
 }

--- a/themes/grunge-contrast.json
+++ b/themes/grunge-contrast.json
@@ -536,7 +536,7 @@
         "terminal.ansiBrightWhite":"#aeaca9",
         "terminal.ansiBrightYellow":"#fed75d",
         "extensionButton.prominentBackground":"#d1f2a5",
-        "extensionButton.prominentForeground":"#ffffff",
+        "extensionButton.prominentForeground":"#5c634f",
         "extensionButton.prominentHoverBackground":"#e8f8d2"
             }
 }

--- a/themes/grunge.json
+++ b/themes/grunge.json
@@ -536,7 +536,7 @@
         "terminal.ansiBrightWhite":"#aeaca9",
         "terminal.ansiBrightYellow":"#fed75d",
         "extensionButton.prominentBackground":"#d1f2a5",
-        "extensionButton.prominentForeground":"#ffffff",
+        "extensionButton.prominentForeground":"#5c634f",
         "extensionButton.prominentHoverBackground":"#e8f8d2"
             }
 }

--- a/themes/slime-contrast.json
+++ b/themes/slime-contrast.json
@@ -536,7 +536,7 @@
         "terminal.ansiBrightWhite":"#aeaca9",
         "terminal.ansiBrightYellow":"#fed75d",
         "extensionButton.prominentBackground":"#d8e778",
-        "extensionButton.prominentForeground":"#ffffff",
+        "extensionButton.prominentForeground":"#3b3a32",
         "extensionButton.prominentHoverBackground":"#e5efa3"
             }
 }

--- a/themes/slime.json
+++ b/themes/slime.json
@@ -536,7 +536,7 @@
         "terminal.ansiBrightWhite":"#aeaca9",
         "terminal.ansiBrightYellow":"#fed75d",
         "extensionButton.prominentBackground":"#faffdb",
-        "extensionButton.prominentForeground":"#ffffff",
+        "extensionButton.prominentForeground":"#3b3a32",
         "extensionButton.prominentHoverBackground":"#ffffff"
             }
 }

--- a/themes/sourlick-contrast.json
+++ b/themes/sourlick-contrast.json
@@ -536,7 +536,7 @@
         "terminal.ansiBrightWhite":"#aeaca9",
         "terminal.ansiBrightYellow":"#fed75d",
         "extensionButton.prominentBackground":"#edf252",
-        "extensionButton.prominentForeground":"#ffffff",
+        "extensionButton.prominentForeground":"#3b3a32",
         "extensionButton.prominentHoverBackground":"#f2f681"
             }
 }

--- a/themes/sourlick.json
+++ b/themes/sourlick.json
@@ -536,7 +536,7 @@
         "terminal.ansiBrightWhite":"#aeaca9",
         "terminal.ansiBrightYellow":"#fed75d",
         "extensionButton.prominentBackground":"#edf252",
-        "extensionButton.prominentForeground":"#ffffff",
+        "extensionButton.prominentForeground":"#3b3a32",
         "extensionButton.prominentHoverBackground":"#f2f681"
             }
 }

--- a/themes/tickle.json
+++ b/themes/tickle.json
@@ -536,7 +536,7 @@
         "terminal.ansiBrightWhite":"#aeaca9",
         "terminal.ansiBrightYellow":"#fed75d",
         "extensionButton.prominentBackground":"#85ffc7",
-        "extensionButton.prominentForeground":"#ffffff",
+        "extensionButton.prominentForeground":"#35443d",
         "extensionButton.prominentHoverBackground":"#b8ffde"
             }
 }


### PR DESCRIPTION
Some colors got too low contrast. I made them the same color as `badge.foreground`
Before:
![before](https://user-images.githubusercontent.com/9638156/34210968-b16fc3f8-e5a8-11e7-983c-a9a3645189d4.png)
After:
![after](https://user-images.githubusercontent.com/9638156/34210971-b549115a-e5a8-11e7-9458-b10751d49696.png)
